### PR TITLE
bump solidus dependency to >= 1.2.0 (no alpha) 

### DIFF
--- a/solidus_virtual_gift_card.gemspec
+++ b/solidus_virtual_gift_card.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "solidus_virtual_gift_card"
-  s.version     = "1.1.0"
+  s.version     = "1.1.1"
   s.summary     = "Virtual gift card for purchase, drops into the user's account as store credit"
   s.required_ruby_version = ">= 2.1"
 
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "solidus", [">= 1.2.0.alpha", "< 1.3.0"]
+  s.add_dependency "solidus", [">= 1.2.0", "< 1.3.0"]
 
   s.add_development_dependency "rspec-rails", "~> 3.2"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Current gem version is not compatible with Solidus 1.2.0

Bumped dependency + gem version

> Bundler could not find compatible versions for gem "solidus": 
>  In Gemfile:
>     solidus_virtual_gift_card (= 1.0.1) ruby depends on
>       solidus (< 1.2.0, >= 1.0.0) ruby