### PR TITLE
add gift card checkbox to admin products form

### DIFF
--- a/app/overrides/spree/admin/products/_form/add_gift_card.html.erb.deface
+++ b/app/overrides/spree/admin/products/_form/add_gift_card.html.erb.deface
@@ -1,0 +1,8 @@
+<!-- insert_bottom '[data-hook="admin_product_form_right"]' -->
+<div class="field">
+  <%= f.check_box(:gift_card) %> 
+  <%= f.label :gift_card, Spree.t("admin.gift_cards.gift_card") %>
+  <span class="info">
+    Turn this product into a gift card?
+  </span>
+</div>

--- a/spec/features/admin/products_card_spec.rb
+++ b/spec/features/admin/products_card_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'Gift Cards', :type => :feature, :js => true do
+  stub_authorization!
+
+  let(:admin_user) { create(:admin_user) }
+
+  before do
+    allow_any_instance_of(Spree::Admin::BaseController).to receive(:spree_current_user).and_return(admin_user)
+  end
+
+  describe "edit product" do
+    let(:product) { create(:product, available_on: 1.year.from_now) }
+
+    it "can mark a product as a gift card" do
+      visit spree.admin_product_path(product)
+
+      find('#product_gift_card').click
+
+      click_on 'Update'
+
+      expect(page).to have_content("successfully updated!")
+      expect(page).to have_field('product_gift_card', checked: true)
+    end
+  end
+end


### PR DESCRIPTION
this seems to be missing from the product admin. 

this changes should allow admin users to mark which products will act as gift cards.