### PR TITLE
Switch from Store.current to Store.default to avoid deprecation.

### DIFF
--- a/app/mailers/spree/gift_card_mailer.rb
+++ b/app/mailers/spree/gift_card_mailer.rb
@@ -3,7 +3,7 @@ class Spree::GiftCardMailer < Spree::BaseMailer
     @gift_card = gift_card.respond_to?(:id) ? gift_card : Spree::VirtualGiftCard.find(gift_card)
     @order = @gift_card.line_item.order
     send_to_address = @gift_card.recipient_email.presence || @order.email
-    subject = "#{Spree::Store.current.name} #{Spree.t('gift_card_mailer.gift_card_email.subject')}"
-    mail(to: send_to_address, from: from_address(Spree::Store.current), subject: subject)
+    subject = "#{Spree::Store.default.name} #{Spree.t('gift_card_mailer.gift_card_email.subject')}"
+    mail(to: send_to_address, from: from_address(Spree::Store.default), subject: subject)
   end
 end


### PR DESCRIPTION
In Solidus 1.4, calling Store.current without an indication of what store results in a deprecation warning. In current Solidus `master` branch it turns into an error. This avoids the deprecation warning and makes it compatible with `master`.