### PR TITLE
Pass string, rather than class, to `:class_name`

### DIFF
--- a/app/models/concerns/spree/gift_cards/line_item_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/line_item_concerns.rb
@@ -3,7 +3,7 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
-      has_many :gift_cards, class_name: Spree::VirtualGiftCard, dependent: :destroy
+      has_many :gift_cards, class_name: 'Spree::VirtualGiftCard', dependent: :destroy
       delegate :gift_card?, :gift_card, to: :product
       self.whitelisted_ransackable_associations += %w[order]
       prepend(InstanceMethods)


### PR DESCRIPTION
In Rail 5.1, passing a class to `:class_name` is deprecated, and in Rails 5.2 it will return the following exception:

```ArgumentError: A class was passed to `:class_name` but we are expecting a string.```