### PR TITLE
single quotes for static strings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,18 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-gem "solidus", github: "solidusio/solidus", branch: branch
-gem "solidus_auth_devise"
+gem 'solidus', github: 'solidusio/solidus', branch: branch
+gem 'solidus_auth_devise'
 
-if branch == 'master' || branch >= "v2.0"
-  gem "rails-controller-testing", group: :test
+if branch == 'master' || branch >= 'v2.0'
+  gem 'rails-controller-testing', group: :test
 end
 
 gem 'pg'
 gem 'mysql2'
 
 group :development, :test do
-  gem "pry-rails"
+  gem 'pry-rails'
 end
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,9 @@ require 'spree/testing_support/extension_rake'
 RSpec::Core::RakeTask.new
 
 task :default do
-  if Dir["spec/dummy"].empty?
+  if Dir['spec/dummy'].empty?
     Rake::Task[:test_app].invoke
-    Dir.chdir("../../")
+    Dir.chdir('../../')
   end
   Rake::Task[:spec].invoke
 end

--- a/app/controllers/spree/admin/gift_cards_controller.rb
+++ b/app/controllers/spree/admin/gift_cards_controller.rb
@@ -17,34 +17,34 @@ class Spree::Admin::GiftCardsController < Spree::Admin::BaseController
 
   def update
     if @gift_card.update_attributes(gift_card_params)
-      flash[:success] = Spree.t("admin.gift_cards.gift_card_updated")
+      flash[:success] = Spree.t('admin.gift_cards.gift_card_updated')
       redirect_to edit_admin_order_path(@order)
     else
-      flash[:error] = @gift_card.errors.full_messages.join(", ")
+      flash[:error] = @gift_card.errors.full_messages.join(', ')
       redirect_to :back
     end
   end
 
   def redeem
     if @gift_card.redeem(@user)
-      flash[:success] = Spree.t("admin.gift_cards.redeemed_gift_card")
+      flash[:success] = Spree.t('admin.gift_cards.redeemed_gift_card')
       redirect_to admin_user_store_credits_path(@user)
     else
-      flash[:error] = Spree.t("admin.gift_cards.errors.unable_to_redeem_gift_card")
+      flash[:error] = Spree.t('admin.gift_cards.errors.unable_to_redeem_gift_card')
       render :lookup
     end
   end
 
   def deactivate
     if @gift_card.deactivate
-      flash[:success] = Spree.t("admin.gift_cards.deactivated_gift_card")
+      flash[:success] = Spree.t('admin.gift_cards.deactivated_gift_card')
       redirect_to edit_admin_order_path(@order)
     else
-      flash[:error] = @gift_card.errors.full_messages.join(", ").presence || Spree.t("admin.gift_cards.errors.unable_to_reimburse_gift_card")
+      flash[:error] = @gift_card.errors.full_messages.join(', ').presence || Spree.t('admin.gift_cards.errors.unable_to_reimburse_gift_card')
       redirect_to edit_admin_order_gift_card_path(@order, @gift_card)
     end
   rescue Spree::Reimbursement::IncompleteReimbursementError
-    flash[:error] = Spree.t("admin.gift_cards.errors.unable_to_reimburse_gift_card")
+    flash[:error] = Spree.t('admin.gift_cards.errors.unable_to_reimburse_gift_card')
     redirect_to edit_admin_order_gift_card_path(@order, @gift_card)
   end
 
@@ -60,7 +60,7 @@ class Spree::Admin::GiftCardsController < Spree::Admin::BaseController
     @gift_card = Spree::VirtualGiftCard.active_by_redemption_code(redemption_code)
 
     if @gift_card.blank?
-      flash[:error] = Spree.t("admin.gift_cards.errors.not_found")
+      flash[:error] = Spree.t('admin.gift_cards.errors.not_found')
       render :lookup
     end
   end

--- a/app/controllers/spree/api/gift_cards_controller.rb
+++ b/app/controllers/spree/api/gift_cards_controller.rb
@@ -1,7 +1,7 @@
 class Spree::Api::GiftCardsController < Spree::Api::BaseController
 
   def redeem
-    redemption_code = Spree::RedemptionCodeGenerator.format_redemption_code_for_lookup(params[:redemption_code] || "")
+    redemption_code = Spree::RedemptionCodeGenerator.format_redemption_code_for_lookup(params[:redemption_code] || '')
     @gift_card = Spree::VirtualGiftCard.active_by_redemption_code(redemption_code)
 
     if !@gift_card

--- a/app/models/concerns/spree/gift_cards/order_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/order_concerns.rb
@@ -13,10 +13,10 @@ module Spree
     module InstanceMethods
       def gift_card_match(line_item, options)
         return true unless line_item.gift_card?
-        return true unless options["gift_card_details"]
+        return true unless options['gift_card_details']
         line_item.gift_cards.any? do |gift_card|
-          gc_detail_set = gift_card.details.stringify_keys.except("send_email_at").to_set
-          options_set = options["gift_card_details"].except("send_email_at").to_set
+          gc_detail_set = gift_card.details.stringify_keys.except('send_email_at').to_set
+          options_set = options['gift_card_details'].except('send_email_at').to_set
           gc_detail_set.superset?(options_set)
         end
       end

--- a/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
@@ -10,7 +10,7 @@ module Spree
     module InstanceMethods
       def add(variant, quantity = 1, options = {})
         line_item = super
-        create_gift_cards(line_item, quantity, options["gift_card_details"] || {})
+        create_gift_cards(line_item, quantity, options['gift_card_details'] || {})
         line_item
       end
 
@@ -41,11 +41,11 @@ module Spree
               amount: line_item.price,
               currency: line_item.currency,
               line_item: line_item,
-              recipient_name: gift_card_details["recipient_name"],
-              recipient_email: gift_card_details["recipient_email"],
-              purchaser_name: gift_card_details["purchaser_name"],
-              gift_message: gift_card_details["gift_message"],
-              send_email_at: format_date(gift_card_details["send_email_at"])
+              recipient_name: gift_card_details['recipient_name'],
+              recipient_email: gift_card_details['recipient_email'],
+              purchaser_name: gift_card_details['purchaser_name'],
+              gift_message: gift_card_details['gift_message'],
+              send_email_at: format_date(gift_card_details['send_email_at'])
             )
           end
         end

--- a/app/models/spree/store_credit_category_decorator.rb
+++ b/app/models/spree/store_credit_category_decorator.rb
@@ -1,2 +1,2 @@
-Spree::StoreCreditCategory::GIFT_CARD_CATEGORY_NAME = "Gift Card".freeze
+Spree::StoreCreditCategory::GIFT_CARD_CATEGORY_NAME = 'Gift Card'.freeze
 Spree::StoreCreditCategory.non_expiring_credit_types |= [Spree::StoreCreditCategory::GIFT_CARD_CATEGORY_NAME]

--- a/app/models/spree/virtual_gift_card.rb
+++ b/app/models/spree/virtual_gift_card.rb
@@ -76,7 +76,7 @@ class Spree::VirtualGiftCard < Spree::Base
   end
 
   def formatted_redemption_code
-    redemption_code.present? ? redemption_code.scan(/.{4}/).join('-') : ""
+    redemption_code.present? ? redemption_code.scan(/.{4}/).join('-') : ''
   end
 
   def formatted_amount
@@ -84,23 +84,23 @@ class Spree::VirtualGiftCard < Spree::Base
   end
 
   def formatted_send_email_at
-    send_email_at.strftime("%-m/%-d/%y") if send_email_at
+    send_email_at.strftime('%-m/%-d/%y') if send_email_at
   end
 
   def formatted_sent_at
-    sent_at.strftime("%-m/%-d/%y") if sent_at
+    sent_at.strftime('%-m/%-d/%y') if sent_at
   end
 
   def formatted_created_at
-    created_at.localtime.strftime("%F %I:%M%p")
+    created_at.localtime.strftime('%F %I:%M%p')
   end
 
   def formatted_redeemed_at
-    redeemed_at.localtime.strftime("%F %I:%M%p") if redeemed_at
+    redeemed_at.localtime.strftime('%F %I:%M%p') if redeemed_at
   end
 
   def formatted_deactivated_at
-    deactivated_at.localtime.strftime("%F %I:%M%p") if deactivated_at
+    deactivated_at.localtime.strftime('%F %I:%M%p') if deactivated_at
   end
 
   def store_credit_category

--- a/app/overrides/admin_gift_card_order_confirmation.rb
+++ b/app/overrides/admin_gift_card_order_confirmation.rb
@@ -1,6 +1,6 @@
 Deface::Override.new(
-  virtual_path: "spree/admin/orders/confirm",
-  name: "add_gift_cards_to_admin_order_confirmation",
-  insert_before: "#order-total",
-  partial: "spree/admin/orders/confirmation_gift_card_details",
+  virtual_path: 'spree/admin/orders/confirm',
+  name: 'add_gift_cards_to_admin_order_confirmation',
+  insert_before: '#order-total',
+  partial: 'spree/admin/orders/confirmation_gift_card_details'
 )

--- a/app/overrides/admin_item_view_gift_card_codes.rb
+++ b/app/overrides/admin_item_view_gift_card_codes.rb
@@ -1,20 +1,20 @@
 Deface::Override.new(
-  virtual_path: "spree/admin/orders/_line_items",
-  name: "add_gift_cards_to_admin_line_items",
-  insert_bottom: ".line-item-name",
-  partial: "spree/admin/orders/cart_gift_card_details",
+  virtual_path: 'spree/admin/orders/_line_items',
+  name: 'add_gift_cards_to_admin_line_items',
+  insert_bottom: '.line-item-name',
+  partial: 'spree/admin/orders/cart_gift_card_details'
 )
 
 Deface::Override.new(
-  virtual_path: "spree/admin/orders/_shipment_manifest",
-  name: "admin_item_view_gift_card_codes",
-  insert_bottom: ".item-name",
-  partial: "spree/admin/orders/shipments_gift_card_details",
+  virtual_path: 'spree/admin/orders/_shipment_manifest',
+  name: 'admin_item_view_gift_card_codes',
+  insert_bottom: '.item-name',
+  partial: 'spree/admin/orders/shipments_gift_card_details'
 )
 
 Deface::Override.new(
-  virtual_path: "spree/admin/orders/_carton_manifest",
-  name: "admin_item_view_gift_card_codes",
-  insert_bottom: ".item-name",
-  partial: "spree/admin/orders/shipments_gift_card_details",
+  virtual_path: 'spree/admin/orders/_carton_manifest',
+  name: 'admin_item_view_gift_card_codes',
+  insert_bottom: '.item-name',
+  partial: 'spree/admin/orders/shipments_gift_card_details'
 )

--- a/app/overrides/admin_user_sidebar_store_credits.rb
+++ b/app/overrides/admin_user_sidebar_store_credits.rb
@@ -1,6 +1,6 @@
 Deface::Override.new(
-  virtual_path: "spree/admin/users/_sidebar",
-  name: "admin_user_sidebar_store_credits",
+  virtual_path: 'spree/admin/users/_sidebar',
+  name: 'admin_user_sidebar_store_credits',
   insert_bottom: "[data-hook='admin_user_tab_options']",
-  partial: "spree/admin/users/gift_card_sidebar",
+  partial: 'spree/admin/users/gift_card_sidebar'
 )

--- a/app/overrides/admin_user_sub_menu.rb
+++ b/app/overrides/admin_user_sub_menu.rb
@@ -1,6 +1,6 @@
 Deface::Override.new(
-  virtual_path: "spree/admin/shared/_tabs",
-  name: "admin_user_sub_menu_index",
+  virtual_path: 'spree/admin/shared/_tabs',
+  name: 'admin_user_sub_menu_index',
   replace: "erb[loud]:contains('BackendConfiguration::USER_TABS')",
   text: <<-ERB)
 <%= tab *Spree::BackendConfiguration::USER_TABS, url: spree.admin_users_path, icon: 'user' do %>

--- a/lib/generators/solidus_virtual_gift_card/install/install_generator.rb
+++ b/lib/generators/solidus_virtual_gift_card/install/install_generator.rb
@@ -9,7 +9,7 @@ module SolidusVirtualGiftCard
       end
 
       def include_seed_data
-        append_file "db/seeds.rb", <<-SEEDS
+        append_file 'db/seeds.rb', <<-SEEDS
 \n
 SpreeVirtualGiftCard::Engine.load_seed if defined?(SpreeVirtualGiftCard::Engine)
         SEEDS

--- a/lib/spree_virtual_gift_card/engine.rb
+++ b/lib/spree_virtual_gift_card/engine.rb
@@ -1,16 +1,16 @@
 module SpreeVirtualGiftCard
   class Engine < Rails::Engine
-    require "solidus_core"
+    require 'solidus_core'
 
     isolate_namespace Spree
-    engine_name "solidus_virtual_gift_card"
+    engine_name 'solidus_virtual_gift_card'
 
     config.generators do |g|
       g.test_framework :rspec
     end
 
     def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), "../../app/**/*_decorator*.rb")) do |c|
+      Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
     end

--- a/lib/spree_virtual_gift_card/factories.rb
+++ b/lib/spree_virtual_gift_card/factories.rb
@@ -6,9 +6,9 @@ FactoryGirl.define do
   factory :virtual_gift_card, class: Spree::VirtualGiftCard do
     association :line_item, factory: :line_item
     amount 25.0
-    currency "USD"
-    recipient_name "Tom Riddle"
-    recipient_email "me@lordvoldemort.com"
+    currency 'USD'
+    recipient_name 'Tom Riddle'
+    recipient_email 'me@lordvoldemort.com'
 
     factory :redeemable_virtual_gift_card do
       association :purchaser, factory: :user

--- a/lib/tasks/send_gift_card_emails.rake
+++ b/lib/tasks/send_gift_card_emails.rake
@@ -1,5 +1,5 @@
 namespace :solidus_virtual_gift_card do
-  desc "Send todays gift card emails"
+  desc 'Send todays gift card emails'
   task :send_current_emails => :environment do
     Spree::VirtualGiftCard.where(send_email_at: Date.today, sent_at: nil, redeemable: true).find_each do |gift_card|
       gift_card.send_email

--- a/solidus_virtual_gift_card.gemspec
+++ b/solidus_virtual_gift_card.gemspec
@@ -2,32 +2,32 @@
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
-  s.name        = "solidus_virtual_gift_card"
-  s.version     = "1.2.0"
+  s.name        = 'solidus_virtual_gift_card'
+  s.version     = '1.2.0'
   s.summary     = "Virtual gift card for purchase, drops into the user's account as store credit"
   s.required_ruby_version = ">= 2.1"
 
-  s.author    = "Solidus Team"
-  s.email     = "contact@solidus.io"
-  s.homepage  = "https://solidus.io"
-  s.license   = "BSD-3-Clause"
+  s.author    = 'Solidus Team'
+  s.email     = 'contact@solidus.io'
+  s.homepage  = 'https://solidus.io'
+  s.license   = 'BSD-3-Clause'
 
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.require_path = "lib"
-  s.requirements << "none"
+  s.require_path = 'lib'
+  s.requirements << 'none'
 
   s.add_dependency "solidus", [">= 1.2", "< 3"]
-  s.add_dependency "deface"
+  s.add_dependency 'deface'
 
-  s.add_development_dependency "rspec-rails", "~> 3.2"
-  s.add_development_dependency "simplecov"
-  s.add_development_dependency "sqlite3"
-  s.add_development_dependency "sass-rails"
-  s.add_development_dependency "coffee-rails"
-  s.add_development_dependency "factory_girl"
-  s.add_development_dependency "capybara", "~> 2.18"
-  s.add_development_dependency "poltergeist"
-  s.add_development_dependency "database_cleaner"
-  s.add_development_dependency "ffaker"
+  s.add_development_dependency 'rspec-rails', '~> 3.2'
+  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sass-rails'
+  s.add_development_dependency 'coffee-rails'
+  s.add_development_dependency 'factory_bot'
+  s.add_development_dependency 'capybara', '~> 2.18'
+  s.add_development_dependency 'poltergeist'
+  s.add_development_dependency 'database_cleaner'
+  s.add_development_dependency 'ffaker'
 end

--- a/spec/controllers/spree/admin/gift_cards_controller_spec.rb
+++ b/spec/controllers/spree/admin/gift_cards_controller_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 describe Spree::Admin::GiftCardsController do
   stub_authorization!
   let!(:gc_category) { create(:store_credit_gift_card_category) }
-  let!(:credit_type) { create(:secondary_credit_type, name: "Non-expiring") }
+  let!(:credit_type) { create(:secondary_credit_type, name: 'Non-expiring') }
 
   describe 'GET index' do
     subject { spree_get :index }
 
-    it "returns a 200 status code" do
+    it 'returns a 200 status code' do
       subject
-      expect(response.code).to eq "200"
+      expect(response.code).to eq '200'
     end
   end
 
@@ -18,9 +18,9 @@ describe Spree::Admin::GiftCardsController do
     let(:user) { create :user }
     subject { spree_get :lookup, user_id: user.id }
 
-    it "returns a 200 status code" do
+    it 'returns a 200 status code' do
       subject
-      expect(response.code).to eq "200"
+      expect(response.code).to eq '200'
     end
   end
 
@@ -32,48 +32,48 @@ describe Spree::Admin::GiftCardsController do
 
     subject { spree_put :deactivate, id: gift_card.id, order_id: order.number  }
 
-    context "when successful" do
-      it "redirects to the admin order edit page" do
+    context 'when successful' do
+      it 'redirects to the admin order edit page' do
         expect(subject).to redirect_to spree.edit_admin_order_path(order)
       end
 
-      it "deactivates the gift card" do
+      it 'deactivates the gift card' do
         subject
         expect(gift_card.reload.deactivated_at).to be_present
       end
     end
 
-    context "when deactivating fails without raising an exception" do
+    context 'when deactivating fails without raising an exception' do
       before { expect_any_instance_of(Spree::VirtualGiftCard).to receive(:deactivate).and_return(false) }
 
-      it "does not deactivate the gift card" do
+      it 'does not deactivate the gift card' do
         subject
         expect(gift_card.reload.deactivated_at).to be_nil
       end
 
-      it "redirects to gift card edit page" do
+      it 'redirects to gift card edit page' do
         expect(subject).to redirect_to spree.edit_admin_order_gift_card_path(order, gift_card)
       end
 
-      it "sets the flash message" do
+      it 'sets the flash message' do
         subject
         expect(flash[:error]).to eq Spree.t('admin.gift_cards.errors.unable_to_reimburse_gift_card')
       end
     end
 
-    context "when deactivating fails from reimbursement" do
+    context 'when deactivating fails from reimbursement' do
       before { expect_any_instance_of(Spree::VirtualGiftCard).to receive(:deactivate).and_raise(Spree::Reimbursement::IncompleteReimbursementError) }
 
-      it "does not deactivate the gift card" do
+      it 'does not deactivate the gift card' do
         subject
         expect(gift_card.reload.deactivated_at).to be_nil
       end
 
-      it "redirects to gift card edit page" do
+      it 'redirects to gift card edit page' do
         expect(subject).to redirect_to spree.edit_admin_order_gift_card_path(order, gift_card)
       end
 
-      it "sets the flash message" do
+      it 'sets the flash message' do
         subject
         expect(flash[:error]).to eq Spree.t('admin.gift_cards.errors.unable_to_reimburse_gift_card')
       end
@@ -87,46 +87,45 @@ describe Spree::Admin::GiftCardsController do
 
     subject { spree_post :redeem, user_id: user.id, gift_card: { redemption_code: redemption_code } }
 
-    context "with a gift card that has not yet been redeemed" do
-
-      it "redirects to store credit index" do
+    context 'with a gift card that has not yet been redeemed' do
+      it 'redirects to store credit index' do
         expect(subject).to redirect_to spree.admin_user_store_credits_path(user)
       end
 
-      it "redeems the gift card" do
+      it 'redeems the gift card' do
         subject
         expect(gift_card.reload.redeemed?).to eq true
       end
 
-      it "sets the redeemer to the correct user" do
+      it 'sets the redeemer to the correct user' do
         subject
         expect(gift_card.reload.redeemer).to eq user
       end
 
-      it "creates store credit for the user" do
+      it 'creates store credit for the user' do
         subject
         expect(user.reload.store_credits.count).to eq 1
       end
 
-      it "sets the store credit equal to the amount of the gift card" do
+      it 'sets the store credit equal to the amount of the gift card' do
         subject
         expect(user.reload.store_credits.first.amount).to eq gift_card.amount
       end
     end
 
-    context "with a gift card that has already been redeemed" do
+    context 'with a gift card that has already been redeemed' do
       before(:each) { gift_card.update_attribute(:redeemed_at, Date.yesterday) }
 
-      it "renders the lookup page" do
+      it 'renders the lookup page' do
         subject
         expect(response).to render_template(:lookup)
       end
     end
 
-    context "with a gift card code that does not exist" do
-      let(:redemption_code) { "INVALID-REDEMPTION-CODE" }
+    context 'with a gift card code that does not exist' do
+      let(:redemption_code) { 'INVALID-REDEMPTION-CODE' }
 
-      it "renders the lookup page" do
+      it 'renders the lookup page' do
         subject
         expect(response).to render_template(:lookup)
       end

--- a/spec/controllers/spree/api/gift_cards_controller_spec.rb
+++ b/spec/controllers/spree/api/gift_cards_controller_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe Spree::Api::GiftCardsController do
   render_views
-  let!(:credit_type) { create(:secondary_credit_type, name: "Non-expiring") }
+  let!(:credit_type) { create(:secondary_credit_type, name: 'Non-expiring') }
   let!(:gc_category) { create(:store_credit_gift_card_category) }
 
-  describe "POST redeem" do
+  describe 'POST redeem' do
     let(:gift_card) { create(:redeemable_virtual_gift_card) }
 
     let(:parameters) do
@@ -16,16 +16,16 @@ describe Spree::Api::GiftCardsController do
 
     subject { spree_post :redeem, parameters, { format: :json } }
 
-    context "the user is not logged in" do
+    context 'the user is not logged in' do
 
       before { subject }
 
-      it "returns a 401" do
+      it 'returns a 401' do
         expect(response.status).to eq 401
       end
     end
 
-    context "the current api user is authenticated" do
+    context 'the current api user is authenticated' do
       let(:api_user) { create(:user) }
 
       before do
@@ -35,7 +35,7 @@ describe Spree::Api::GiftCardsController do
 
       let(:parsed_response) { HashWithIndifferentAccess.new(JSON.parse(response.body)) }
 
-      context "given an invalid gift card redemption code" do
+      context 'given an invalid gift card redemption code' do
         before { subject }
 
         let(:parameters) do
@@ -52,21 +52,20 @@ describe Spree::Api::GiftCardsController do
           expect(parsed_response['error_message']).to be_present
         end
 
-        it "returns a 404" do
+        it 'returns a 404' do
           expect(subject.status).to eq 404
         end
       end
 
-      context "there is no redemption code in the request body" do
+      context 'there is no redemption code in the request body' do
         let(:parameters) { {} }
 
-        it "returns a 404" do
+        it 'returns a 404' do
           expect(subject.status).to eq 404
         end
       end
 
-      context "given a valid gift card redemption code" do
-
+      context 'given a valid gift card redemption code' do
         it 'finds the gift card' do
           subject
           expect(assigns(:gift_card)).to eq gift_card
@@ -78,7 +77,7 @@ describe Spree::Api::GiftCardsController do
           subject
         end
 
-        it "returns a 201" do
+        it 'returns a 201' do
           subject
           expect(subject.status).to eq 201
         end

--- a/spec/features/admin/gift_cards_spec.rb
+++ b/spec/features/admin/gift_cards_spec.rb
@@ -9,32 +9,32 @@ describe 'Gift Cards', :type => :feature, :js => true do
     allow_any_instance_of(Spree::Admin::BaseController).to receive(:spree_current_user).and_return(admin_user)
   end
 
-  describe "edit gift card" do
+  describe 'edit gift card' do
     let(:gift_card) { create(:redeemable_virtual_gift_card) }
     let(:order) { gift_card.line_item.order }
-    let(:new_recipient_name) { "Heidi" }
-    let(:new_recipient_email) { "heidi@gmail.com" }
-    let(:new_purchaser_name) { "Neerali" }
-    let(:new_gift_message) { "Sweaters!" }
+    let(:new_recipient_name) { 'Heidi' }
+    let(:new_recipient_email) { 'heidi@gmail.com' }
+    let(:new_purchaser_name) { 'Neerali' }
+    let(:new_gift_message) { 'Sweaters!' }
 
-    it "can edit recipient information and send email date" do
+    it 'can edit recipient information and send email date' do
       visit spree.cart_admin_order_path(order)
 
-      within ".line-item-name" do
-        click_link("Edit Details")
+      within '.line-item-name' do
+        click_link('Edit Details')
       end
 
-      fill_in "virtual_gift_card_recipient_name", with: new_recipient_name
-      fill_in "virtual_gift_card_recipient_email", with: new_recipient_email
-      fill_in "virtual_gift_card_purchaser_name", with: new_purchaser_name
-      fill_in "virtual_gift_card_gift_message", with: new_gift_message
-      fill_in "virtual_gift_card_send_email_at", with: Date.tomorrow
+      fill_in 'virtual_gift_card_recipient_name', with: new_recipient_name
+      fill_in 'virtual_gift_card_recipient_email', with: new_recipient_email
+      fill_in 'virtual_gift_card_purchaser_name', with: new_purchaser_name
+      fill_in 'virtual_gift_card_gift_message', with: new_gift_message
+      fill_in 'virtual_gift_card_send_email_at', with: Date.tomorrow
 
       # Just so the datepicker gets out of poltergeists way.
       page.execute_script("$('#virtual_gift_card_send_email_at').datepicker('widget').hide();")
 
       click_on 'Update'
-      expect(page).to have_content("Gift card updated!")
+      expect(page).to have_content('Gift card updated!')
       expect(gift_card.reload.recipient_name).to eq(new_recipient_name)
       expect(gift_card.recipient_email).to eq(new_recipient_email)
       expect(gift_card.purchaser_name).to eq(new_purchaser_name)
@@ -42,30 +42,30 @@ describe 'Gift Cards', :type => :feature, :js => true do
     end
   end
 
-  describe "lookup a gift card" do
+  describe 'lookup a gift card' do
     let(:gift_card) { create(:redeemable_virtual_gift_card,
-                             recipient_name: "Daeva",
+                             recipient_name: 'Daeva',
                              recipient_email: 'dog@example.com',
                             )
     }
     let(:other_gift_card) { create(:redeemable_virtual_gift_card)}
     let(:order) { gift_card.line_item.order }
 
-    it "can lookup gift card by recipient email" do
+    it 'can lookup gift card by recipient email' do
       visit spree.admin_gift_cards_path
 
-      fill_in "q[recipient_email_cont]", with: gift_card.recipient_email
-      click_on "Lookup Gift Card"
+      fill_in 'q[recipient_email_cont]', with: gift_card.recipient_email
+      click_on 'Lookup Gift Card'
 
       expect(page).to have_content(gift_card.purchaser.email)
       expect(page).to_not have_content(other_gift_card.purchaser.email)
     end
 
-    it "can lookup gift card by order number" do
+    it 'can lookup gift card by order number' do
       visit spree.admin_gift_cards_path
 
-      fill_in "q[line_item_order_number_cont]", with: order.number
-      click_on "Lookup Gift Card"
+      fill_in 'q[line_item_order_number_cont]', with: order.number
+      click_on 'Lookup Gift Card'
 
       expect(page).to have_content(gift_card.purchaser.email)
       expect(page).to_not have_content(other_gift_card.purchaser.email)

--- a/spec/features/admin/products_card_spec.rb
+++ b/spec/features/admin/products_card_spec.rb
@@ -9,17 +9,17 @@ describe 'Gift Cards', type: :feature, js: true do
     allow_any_instance_of(Spree::Admin::BaseController).to receive(:spree_current_user).and_return(admin_user)
   end
 
-  describe "edit product" do
+  describe 'edit product' do
     let(:product) { create(:product, available_on: 1.year.from_now) }
 
-    it "can mark a product as a gift card" do
+    it 'can mark a product as a gift card' do
       visit spree.admin_product_path(product)
 
       find('#product_gift_card').click
 
       click_on 'Update'
 
-      expect(page).to have_content("successfully updated!")
+      expect(page).to have_content('successfully updated!')
       expect(page).to have_field('product_gift_card', checked: true)
     end
   end

--- a/spec/lib/tasks/send_gift_card_emails_spec.rb
+++ b/spec/lib/tasks/send_gift_card_emails_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "solidus_virtual_gift_card:send_current_emails" do
+describe 'solidus_virtual_gift_card:send_current_emails' do
 
   let(:task) { Rake::Task['solidus_virtual_gift_card:send_current_emails'] }
   let(:purchaser) {create(:user)}
@@ -12,46 +12,46 @@ describe "solidus_virtual_gift_card:send_current_emails" do
 
   subject { task.invoke }
 
-  context "with gift card sent today" do
-    it "sends emails to be sent today" do
+  context 'with gift card sent today' do
+    it 'sends emails to be sent today' do
       gift_card = Spree::VirtualGiftCard.create!(amount: 50, send_email_at: Date.today, redeemable: true, purchaser: purchaser)
       expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card).and_return(double(deliver_later: true))
       subject
     end
 
-    it "does not send unredeemable giftcards" do
+    it 'does not send unredeemable giftcards' do
       gift_card = Spree::VirtualGiftCard.create!(amount: 50, send_email_at: Date.today)
       expect(Spree::GiftCardMailer).to_not receive(:gift_card_email).with(gift_card)
       subject
     end
   end
 
-  context "with gift card already sent today" do
-    it "sends emails to be sent today" do
+  context 'with gift card already sent today' do
+    it 'sends emails to be sent today' do
       Spree::VirtualGiftCard.create!(amount: 50, send_email_at: Date.today, sent_at: DateTime.now, redeemable: true, purchaser: purchaser)
       expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
       subject
     end
   end
 
-  context "with gift cards sent in the future" do
-    it "does not sends emails" do
+  context 'with gift cards sent in the future' do
+    it 'does not sends emails' do
       Spree::VirtualGiftCard.create!(amount: 50, send_email_at: 10.days.from_now.to_date, redeemable: true, purchaser: purchaser)
       expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
       subject
     end
   end
 
-  context "with gift cards sent in the past" do
-    it "does not sends emails" do
+  context 'with gift cards sent in the past' do
+    it 'does not sends emails' do
       Spree::VirtualGiftCard.create!(amount: 50, send_email_at: 1.days.ago, sent_at: 1.days.ago.to_date, redeemable: true, purchaser: purchaser)
       expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
       subject
     end
   end
 
-  context "with gift cards not specified" do
-    it "does not sends emails" do
+  context 'with gift cards not specified' do
+    it 'does not sends emails' do
       Spree::VirtualGiftCard.create!(amount: 50, send_email_at: nil)
       expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
       subject

--- a/spec/mailers/spree/gift_card_mailer_spec.rb
+++ b/spec/mailers/spree/gift_card_mailer_spec.rb
@@ -6,13 +6,13 @@ describe Spree::GiftCardMailer, type: :mailer do
 
     subject { Spree::GiftCardMailer.gift_card_email(gift_card) }
 
-    context "the recipient email is blank" do
+    context 'the recipient email is blank' do
       before do
-        gift_card.update_attributes!(recipient_email: "")
-        gift_card.line_item.order.update_attributes!(email: "gift_card_tester@example.com")
+        gift_card.update_attributes!(recipient_email: '')
+        gift_card.line_item.order.update_attributes!(email: 'gift_card_tester@example.com')
       end
 
-      it "uses the email associated with the order" do
+      it 'uses the email associated with the order' do
         expect(subject.to).to contain_exactly('gift_card_tester@example.com')
       end
     end

--- a/spec/models/concerns/spree/redemption_code_generator_spec.rb
+++ b/spec/models/concerns/spree/redemption_code_generator_spec.rb
@@ -14,7 +14,7 @@ describe Spree::RedemptionCodeGenerator do
     subject { Spree::RedemptionCodeGenerator.format_redemption_code_for_lookup(redemption_code) }
 
     context 'redemption code has no dashes' do
-      let(:redemption_code) { "1234ABCD1234ABCD" }
+      let(:redemption_code) { '1234ABCD1234ABCD' }
 
       it 'does nothing to the code' do
         expect(subject).to eq redemption_code
@@ -22,8 +22,8 @@ describe Spree::RedemptionCodeGenerator do
     end
 
     context 'redemption code 4 groups of 4 characters, separated by dashes' do
-      let(:redemption_code) { "1234-ABCD-1234-ABCD" }
-      let(:formatted_redemption_code) { "1234ABCD1234ABCD" }
+      let(:redemption_code) { '1234-ABCD-1234-ABCD' }
+      let(:formatted_redemption_code) { '1234ABCD1234ABCD' }
 
       it 'strips the dashes' do
         expect(subject).to eq formatted_redemption_code
@@ -31,8 +31,8 @@ describe Spree::RedemptionCodeGenerator do
     end
 
     context 'redemption code is mixed-case' do
-      let(:redemption_code) { "1234-aBCd-1234-AbcD" }
-      let(:formatted_redemption_code) { "1234ABCD1234ABCD" }
+      let(:redemption_code) { '1234-aBCd-1234-AbcD' }
+      let(:formatted_redemption_code) { '1234ABCD1234ABCD' }
 
       it 'makes it all upcase' do
         expect(subject).to eq formatted_redemption_code

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::LineItem do
-  describe "#redemption_codes" do
+  describe '#redemption_codes' do
     let(:line_item) { create(:line_item, quantity: 2) }
     let!(:gift_card) { create(:virtual_gift_card, line_item: line_item) }
     let!(:gift_card_2) { create(:virtual_gift_card, line_item: line_item) }
@@ -28,7 +28,7 @@ describe Spree::LineItem do
     end
   end
 
-  describe "#gift_card_details" do
+  describe '#gift_card_details' do
     let(:line_item) { create(:line_item, quantity: 2) }
     let!(:gift_card) { create(:redeemable_virtual_gift_card, line_item: line_item) }
     let!(:gift_card_2) { create(:redeemable_virtual_gift_card, line_item: line_item) }

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -5,40 +5,40 @@ describe Spree::OrderContents do
   let(:variant) { create(:variant) }
   let(:order_contents) { Spree::OrderContents.new(order) }
 
-  let(:recipient_name) { "Ron Weasly" }
-  let(:recipient_email) { "ron@weasly.com" }
-  let(:purchaser_name) { "Harry Potter" }
-  let(:gift_message) { "Thought you could use some trousers, mate" }
+  let(:recipient_name) { 'Ron Weasly' }
+  let(:recipient_email) { 'ron@weasly.com' }
+  let(:purchaser_name) { 'Harry Potter' }
+  let(:gift_message) { 'Thought you could use some trousers, mate' }
   let(:send_email_at) { 2.days.from_now }
   let(:options) do
     {
-      "gift_card_details" => {
-        "recipient_name" => recipient_name,
-        "recipient_email" => recipient_email,
-        "purchaser_name" => purchaser_name,
-        "gift_message" => gift_message,
-        "send_email_at" => send_email_at,
+      'gift_card_details' => {
+        'recipient_name' => recipient_name,
+        'recipient_email' => recipient_email,
+        'purchaser_name' => purchaser_name,
+        'gift_message' => gift_message,
+        'send_email_at' => send_email_at
       }
     }
   end
   let(:quantity) { 1 }
 
-  describe "#add" do
+  describe '#add' do
     subject { order_contents.add(variant, quantity, options) }
 
-    it "creates a line item" do
+    it 'creates a line item' do
       expect { subject }.to change { Spree::LineItem.count }.by(1)
     end
 
-    context "with a gift card product" do
+    context 'with a gift card product' do
       before { variant.product.update_attributes(gift_card: true) }
 
-      it "creates a line item" do
+      it 'creates a line item' do
         expect { subject }.to change { Spree::LineItem.count }.by(1)
       end
 
-      context "with a single gift card" do
-        it "creates a gift card" do
+      context 'with a single gift card' do
+        it 'creates a gift card' do
           expect { subject }.to change { Spree::VirtualGiftCard.count }.by(1)
           gift_card = Spree::VirtualGiftCard.last
           expect(gift_card.recipient_name).to eq(recipient_name)
@@ -48,38 +48,38 @@ describe Spree::OrderContents do
           expect(gift_card.send_email_at).to eq(send_email_at.to_date)
         end
 
-        context "#format_date" do
-          context "without send_email_at" do
+        context '#format_date' do
+          context 'without send_email_at' do
             let(:send_email_at) { nil }
-            it "sets to current date" do
+            it 'sets to current date' do
               subject
               gift_card = Spree::VirtualGiftCard.last
               expect(gift_card.send_email_at).to eq(Date.today)
             end
           end
 
-          context "with invalid date" do
-            let(:send_email_at) { "12/14/2020" }
-            it "errors" do
+          context 'with invalid date' do
+            let(:send_email_at) { '12/14/2020' }
+            it 'errors' do
              expect{ subject }.to raise_error Spree::GiftCards::OrderContentsConcerns::GiftCardDateFormatError
             end
           end
         end
       end
 
-      context "with multiple gift cards" do
+      context 'with multiple gift cards' do
         let(:quantity) { 2 }
 
-        it "creates two gift cards" do
+        it 'creates two gift cards' do
           expect { subject }.to change { Spree::VirtualGiftCard.count }.by(2)
         end
       end
 
-      context "adding a gift card with an existing line item" do
-        context "when the gift card properties match" do
+      context 'adding a gift card with an existing line item' do
+        context 'when the gift card properties match' do
           before { @line_item = order_contents.add(variant, quantity, options) }
 
-          it "adds to the existing gift card" do
+          it 'adds to the existing gift card' do
             expect(order.line_items.count).to be(1)
             new_line_item = subject
             expect(order.reload.line_items.count).to be(1)
@@ -87,25 +87,25 @@ describe Spree::OrderContents do
           end
         end
 
-        context "when the gift card properties are different" do
-          let(:recipient_name2)  { "Severus Snape" }
-          let(:recipient_email2) { "wingardium@leviosa.com" }
-          let(:purchaser_name2)  { "Dumbledore" }
+        context 'when the gift card properties are different' do
+          let(:recipient_name2)  { 'Severus Snape' }
+          let(:recipient_email2) { 'wingardium@leviosa.com' }
+          let(:purchaser_name2)  { 'Dumbledore' }
           let(:options2) do
             {
-              "gift_card_details" => {
-                "recipient_name" => recipient_name2,
-                "recipient_email" => recipient_email2,
-                "purchaser_name" => purchaser_name2,
-                "gift_message" => gift_message,
-                "send_email_at" => send_email_at,
+              'gift_card_details' => {
+                'recipient_name' => recipient_name2,
+                'recipient_email' => recipient_email2,
+                'purchaser_name' => purchaser_name2,
+                'gift_message' => gift_message,
+                'send_email_at' => send_email_at
               }
             }
           end
 
           before { @line_item = order_contents.add(variant, quantity, options2) }
 
-          it "creates a new line item with a gift card" do
+          it 'creates a new line item with a gift card' do
             expect(order.line_items.count).to be(1)
             new_line_item = subject
             expect(@line_item.id).to_not eq new_line_item.id
@@ -116,67 +116,67 @@ describe Spree::OrderContents do
       end
     end
 
-    context "with a non gift card product" do
-      it "does not create a gift card" do
+    context 'with a non gift card product' do
+      it 'does not create a gift card' do
         expect { subject }.to_not change { Spree::VirtualGiftCard.count }
       end
     end
   end
 
-  describe "#remove" do
+  describe '#remove' do
     subject { order_contents.remove(variant, quantity, options) }
 
-    context "for a non-gift-card product" do
+    context 'for a non-gift-card product' do
       before { order_contents.add(variant, quantity, options) }
 
-      it "deletes a line item" do
+      it 'deletes a line item' do
         expect { subject }.to change { Spree::LineItem.count }.by(-1)
       end
     end
 
-    context "with a gift card product" do
+    context 'with a gift card product' do
       before do
         variant.product.update_attributes(gift_card: true)
       end
 
-      context "with a single gift card" do
+      context 'with a single gift card' do
         before do
           order_contents.add(variant, quantity, options)
         end
 
-        it "deletes a line item" do
+        it 'deletes a line item' do
           expect { subject }.to change { Spree::LineItem.count }.by(-1)
         end
 
-        it "deletes a gift card" do
+        it 'deletes a gift card' do
           expect { subject }.to change { Spree::VirtualGiftCard.count }.by(-1)
         end
       end
 
-      context "with multiple gift cards" do
+      context 'with multiple gift cards' do
         let(:quantity) { 2 }
 
         before do
           order_contents.add(variant, quantity, options)
         end
 
-        it "deletes two gift cards" do
+        it 'deletes two gift cards' do
           expect { subject }.to change { Spree::VirtualGiftCard.count }.by(-2)
         end
       end
 
-      context "with two gift card line items with identical variants" do
-        let(:recipient_name2)  { "Severus Snape" }
-        let(:recipient_email2) { "wingardium@leviosa.com" }
-        let(:purchaser_name2)  { "Dumbledore" }
+      context 'with two gift card line items with identical variants' do
+        let(:recipient_name2)  { 'Severus Snape' }
+        let(:recipient_email2) { 'wingardium@leviosa.com' }
+        let(:purchaser_name2)  { 'Dumbledore' }
         let(:options2) do
           {
-            "gift_card_details" => {
-              "recipient_name" => recipient_name2,
-              "recipient_email" => recipient_email2,
-              "purchaser_name" => purchaser_name2,
-              "gift_message" => gift_message,
-              "send_email_at" => send_email_at,
+            'gift_card_details' => {
+              'recipient_name' => recipient_name2,
+              'recipient_email' => recipient_email2,
+              'purchaser_name' => purchaser_name2,
+              'gift_message' => gift_message,
+              'send_email_at' => send_email_at
             }
           }
         end
@@ -186,8 +186,8 @@ describe Spree::OrderContents do
           @line_item2 = order_contents.add(variant, quantity, options2)
         end
 
-        context "removing the first line item" do
-          it "removes the correct line item" do
+        context 'removing the first line item' do
+          it 'removes the correct line item' do
             expect(order.line_items.count).to be(2)
             subject
             expect(order.reload.line_items.count).to be(1)
@@ -195,10 +195,10 @@ describe Spree::OrderContents do
           end
         end
 
-        context "removing the second line item" do
+        context 'removing the second line item' do
           subject { order_contents.remove(variant, quantity, options2) }
 
-          it "removes the correct line item" do
+          it 'removes the correct line item' do
             expect(order.line_items.count).to be(2)
             subject
             expect(order.reload.line_items.count).to be(1)
@@ -207,24 +207,24 @@ describe Spree::OrderContents do
         end
       end
 
-      context "when no gift card details are supplied" do
+      context 'when no gift card details are supplied' do
         subject { order_contents.remove(variant, quantity) }
 
         before do
           order_contents.add(variant, quantity, options)
         end
 
-        it "removes the line item with the correct variant" do
+        it 'removes the line item with the correct variant' do
           expect { subject }.to change { Spree::LineItem.count }.by(-1)
         end
 
-        it "removes the gift card" do
+        it 'removes the gift card' do
           expect { subject }.to change { Spree::VirtualGiftCard.count }.by(-1)
         end
       end
     end
 
-    describe "#update_cart" do
+    describe '#update_cart' do
       subject { order_contents.update_cart(update_params) }
 
       let(:update_params) do
@@ -233,33 +233,33 @@ describe Spree::OrderContents do
         }
       end
 
-      context "for a gift card line item" do
+      context 'for a gift card line item' do
         before do
           variant.product.update_attributes(gift_card: true)
           @line_item = order_contents.add(variant, 2, options)
         end
 
-        context "line item is being updated to a higher quantity" do
-          let(:quantity) { "4" }
+        context 'line item is being updated to a higher quantity' do
+          let(:quantity) { '4' }
 
-          it "creates new gift cards" do
+          it 'creates new gift cards' do
             expect { subject }.to change { Spree::VirtualGiftCard.count }.by(2)
           end
         end
 
-        context "line item is being updated to a lower quantity" do
-          context "one lower" do
-            let(:quantity) { "1" }
+        context 'line item is being updated to a lower quantity' do
+          context 'one lower' do
+            let(:quantity) { '1' }
 
-            it "destroys gift cards" do
+            it 'destroys gift cards' do
               expect { subject }.to change { Spree::VirtualGiftCard.count }.by(-1)
             end
           end
 
-          context "multiple lower" do
-            let(:quantity) { "0" }
+          context 'multiple lower' do
+            let(:quantity) { '0' }
 
-            it "destroys gift cards" do
+            it 'destroys gift cards' do
               expect { subject }.to change { Spree::VirtualGiftCard.count }.by(-2)
             end
           end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe Spree::Order do
-  describe "#finalize!" do
-    context "the order contains gift cards and transitions to complete" do
+  describe '#finalize!' do
+    context 'the order contains gift cards and transitions to complete' do
       let(:gift_card) { create(:virtual_gift_card) }
       let(:order) { create(:order_with_line_items, state: 'complete', line_items: [gift_card.line_item]) }
 
       subject { order.finalize! }
 
-      it "makes the gift card redeemable" do
+      it 'makes the gift card redeemable' do
         subject
         expect(gift_card.reload.redeemable).to be true
         expect(gift_card.reload.redemption_code).to be_present
@@ -16,18 +16,18 @@ describe Spree::Order do
     end
   end
 
-  describe "#send_gift_card_emails" do
+  describe '#send_gift_card_emails' do
     subject { order.send_gift_card_emails }
 
-    context "the order has gift cards" do
+    context 'the order has gift cards' do
       let(:gift_card) { create(:virtual_gift_card, send_email_at: send_email_at) }
       let(:line_item) { gift_card.line_item }
       let(:gift_card_2) { create(:virtual_gift_card, line_item: line_item, send_email_at: send_email_at) }
       let(:order) { gift_card.line_item.order }
 
-      context "send_email_at is not set" do
+      context 'send_email_at is not set' do
         let(:send_email_at) { nil }
-        it "should call GiftCardMailer#send" do
+        it 'should call GiftCardMailer#send' do
           expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card).and_return(double(deliver_later: true))
           expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card_2).and_return(double(deliver_later: true))
           subject
@@ -35,9 +35,9 @@ describe Spree::Order do
         end
       end
 
-      context "send_email_at is in the past" do
+      context 'send_email_at is in the past' do
         let(:send_email_at) { 2.days.ago }
-        it "should call GiftCardMailer#send" do
+        it 'should call GiftCardMailer#send' do
           expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card).and_return(double(deliver_later: true))
           expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card_2).and_return(double(deliver_later: true))
           subject
@@ -45,9 +45,9 @@ describe Spree::Order do
         end
       end
 
-      context "send_email_at is in the future" do
+      context 'send_email_at is in the future' do
         let(:send_email_at) { 2.days.from_now }
-        it "does not call GiftCardMailer#send" do
+        it 'does not call GiftCardMailer#send' do
           expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
           subject
           expect(gift_card.reload.sent_at).to_not be_present
@@ -55,10 +55,10 @@ describe Spree::Order do
       end
     end
 
-    context "no gift cards" do
+    context 'no gift cards' do
       let(:order) { create(:order_with_line_items) }
 
-      it "should not call GiftCardMailer#send" do
+      it 'should not call GiftCardMailer#send' do
         expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
         subject
       end

--- a/spec/models/spree/permission_sets/virtual_gift_card_display_spec.rb
+++ b/spec/models/spree/permission_sets/virtual_gift_card_display_spec.rb
@@ -5,7 +5,7 @@ describe Spree::PermissionSets::VirtualGiftCardDisplay do
 
   subject { ability }
 
-  context "when activated" do
+  context 'when activated' do
     before do
       described_class.new(ability).activate!
     end
@@ -14,7 +14,7 @@ describe Spree::PermissionSets::VirtualGiftCardDisplay do
     it { should be_able_to(:display, Spree::VirtualGiftCard) }
   end
 
-  context "when not activated" do
+  context 'when not activated' do
     it { should_not be_able_to(:admin, Spree::VirtualGiftCard) }
     it { should_not be_able_to(:display, Spree::VirtualGiftCard) }
   end

--- a/spec/models/spree/permission_sets/virtual_gift_card_management_spec.rb
+++ b/spec/models/spree/permission_sets/virtual_gift_card_management_spec.rb
@@ -6,7 +6,7 @@ describe Spree::PermissionSets::VirtualGiftCardManagement do
 
   subject { ability }
 
-  context "when activated" do
+  context 'when activated' do
     before do
       described_class.new(ability).activate!
     end
@@ -14,7 +14,7 @@ describe Spree::PermissionSets::VirtualGiftCardManagement do
     it { should be_able_to(:manage, Spree::VirtualGiftCard) }
   end
 
-  context "when not activated" do
+  context 'when not activated' do
     it { should_not be_able_to(:manage, Spree::VirtualGiftCard) }
   end
 end

--- a/spec/models/spree/store_credit_category_spec.rb
+++ b/spec/models/spree/store_credit_category_spec.rb
@@ -1,21 +1,21 @@
 require 'spec_helper'
 
 describe Spree::StoreCreditCategory, type: :model do
-  describe "#non_expiring?" do
+  describe '#non_expiring?' do
     subject { build(:store_credit_category, name: category_name).non_expiring? }
 
-    context "non-expiring type store credit" do
+    context 'non-expiring type store credit' do
       let(:category_name) { Spree::StoreCreditCategory.non_expiring_credit_types.first }
 
-      it "returns true" do
+      it 'returns true' do
         expect(subject).to be true
       end
     end
 
-    context "expiring type store credit" do
-      let(:category_name) { "Expiring" }
+    context 'expiring type store credit' do
+      let(:category_name) { 'Expiring' }
 
-      it "returns false" do
+      it 'returns false' do
         expect(subject).to be false
       end
     end

--- a/spec/models/spree/virtual_gift_card_spec.rb
+++ b/spec/models/spree/virtual_gift_card_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::VirtualGiftCard do
   let!(:gc_category) { create(:store_credit_gift_card_category) }
-  let!(:credit_type) { create(:secondary_credit_type, name: "Non-expiring") }
+  let!(:credit_type) { create(:secondary_credit_type, name: 'Non-expiring') }
 
   context 'validations' do
     let(:invalid_gift_card) { build(:virtual_gift_card, amount: 0) }
@@ -19,13 +19,13 @@ describe Spree::VirtualGiftCard do
     end
   end
 
-  describe "#can_deactivate?" do
+  describe '#can_deactivate?' do
     subject { gift_card.can_deactivate? }
 
     let!(:default_refund_reason) { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
     let(:gift_card) { create(:redeemable_virtual_gift_card, line_item: order.line_items.first) }
 
-    context "the order is not complete" do
+    context 'the order is not complete' do
       let(:order) { create(:order_with_line_items, line_items_count: 1) }
 
       it "can't deactivate" do
@@ -33,7 +33,7 @@ describe Spree::VirtualGiftCard do
       end
     end
 
-    context "gift card is already deactivated" do
+    context 'gift card is already deactivated' do
       before { gift_card.deactivate }
       let(:order) { create(:shipped_order, line_items_count: 1) }
 
@@ -42,7 +42,7 @@ describe Spree::VirtualGiftCard do
       end
     end
 
-    context "order is not paid" do
+    context 'order is not paid' do
       let(:order) { create(:order_with_line_items, line_items_count: 1) }
 
       it "can't deactivate" do
@@ -50,46 +50,46 @@ describe Spree::VirtualGiftCard do
       end
     end
 
-    context "order is paid and complete and gift card is active" do
+    context 'order is paid and complete and gift card is active' do
       let(:order) { create(:shipped_order, line_items_count: 1) }
 
-      it "can deactivate" do
+      it 'can deactivate' do
         expect(subject).to be_truthy
       end
     end
   end
 
-  describe "#deactivate" do
+  describe '#deactivate' do
     let!(:gift_card) { create(:redeemable_virtual_gift_card, line_item: order.line_items.first) }
     let(:order) { create(:shipped_order, line_items_count: 1) }
     let!(:default_refund_reason) { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
     subject { gift_card.deactivate }
 
-    it "makes it not redeemable" do
+    it 'makes it not redeemable' do
       subject
       expect(gift_card.reload.redeemable?).to be_falsey
     end
 
-    it "sets the deactivated_at" do
+    it 'sets the deactivated_at' do
       subject
       expect(gift_card.reload.deactivated_at).to be_present
     end
 
-    it "#deactivated? returns true" do
+    it '#deactivated? returns true' do
       subject
       expect(gift_card.reload.deactivated?).to be_truthy
     end
 
-    it "cancels the inventory unit" do
+    it 'cancels the inventory unit' do
       subject
       expect(gift_card.inventory_unit.unit_cancel).to be_present
     end
 
-    it "creates a reimbursement" do
+    it 'creates a reimbursement' do
       expect { subject }.to change { Spree::Reimbursement.count }.by(1)
     end
 
-    it "returns true" do
+    it 'returns true' do
       expect(subject).to be_truthy
     end
   end
@@ -101,12 +101,12 @@ describe Spree::VirtualGiftCard do
     let(:inventory_unit) { order.inventory_units.first }
     subject { gift_card.make_redeemable!(purchaser: user, inventory_unit: inventory_unit) }
 
-    it "sets the purchaser" do
+    it 'sets the purchaser' do
       subject
       expect(gift_card.purchaser).to be user
     end
 
-    it "sets the inventory unit" do
+    it 'sets the inventory unit' do
       subject
       expect(gift_card.inventory_unit).to be inventory_unit
     end
@@ -119,9 +119,9 @@ describe Spree::VirtualGiftCard do
     end
 
     context 'redemption code is already set' do
-      let(:expected_code) { "EXPECTEDCODE" }
+      let(:expected_code) { 'EXPECTEDCODE' }
       before { gift_card.redemption_code = expected_code }
-      it "does not update the redemption code" do
+      it 'does not update the redemption code' do
         subject
         expect(gift_card.redemption_code).to eq expected_code
       end
@@ -130,7 +130,7 @@ describe Spree::VirtualGiftCard do
 
     context 'there is a collision on redemption code' do
       context 'the existing giftcard has not been redeemed yet' do
-        let!(:existing_giftcard) { create(:virtual_gift_card, redemption_code: "ABC123-EFG456") }
+        let!(:existing_giftcard) { create(:virtual_gift_card, redemption_code: 'ABC123-EFG456') }
         let(:expected_code) { 'EXPECTEDCODE' }
         let(:generator) { Spree::RedemptionCodeGenerator }
 
@@ -145,7 +145,7 @@ describe Spree::VirtualGiftCard do
       end
 
       context 'the existing gift card has been redeemed' do
-        let!(:existing_giftcard) { create(:virtual_gift_card, redemption_code: "ABC123-EFG456", redeemed_at: Time.now) }
+        let!(:existing_giftcard) { create(:virtual_gift_card, redemption_code: 'ABC123-EFG456', redeemed_at: Time.now) }
         let(:generator) { Spree::RedemptionCodeGenerator }
 
         it 'recursively generates redemption codes' do
@@ -313,17 +313,17 @@ describe Spree::VirtualGiftCard do
     end
   end
 
-  describe "#send_email" do
+  describe '#send_email' do
     let(:gift_card) { create(:redeemable_virtual_gift_card) }
 
     subject { gift_card.send_email }
 
-    it "sends the gift card email" do
+    it 'sends the gift card email' do
       expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card).and_return(double(deliver_later: true))
       subject
     end
 
-    it "sets sent_at" do
+    it 'sets sent_at' do
       expect { subject }.to change { gift_card.sent_at }
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,9 +28,9 @@ require 'spree/testing_support/url_helpers'
 
 require 'cancan/matchers'
 
-require "spree_virtual_gift_card/factories"
+require 'spree_virtual_gift_card/factories'
 
-require "capybara/poltergeist"
+require 'capybara/poltergeist'
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, timeout: 120)
 end
@@ -43,16 +43,16 @@ RSpec.configure do |config|
   config.mock_with :rspec
 
   config.color = true
-  config.order = "random"
+  config.order = 'random'
 
   config.expose_current_running_example_as :example
-  config.fail_fast = ENV["FAIL_FAST"] || false
+  config.fail_fast = ENV['FAIL_FAST'] || false
 
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
   config.use_transactional_fixtures = false
 
-  config.example_status_persistence_file_path = "./spec/examples.txt"
+  config.example_status_persistence_file_path = './spec/examples.txt'
 
   config.include FactoryGirl::Syntax::Methods
   config.include Spree::TestingSupport::ControllerRequests, type: :controller


### PR DESCRIPTION
The use of single quotes for static strings is more performant and is preferred by, e.g., Rubocop and other tools. This updates `solidus_virtual_gift_card` with single quotes for static strings.