### PR TITLE
Add Rails version numbers to migrations

### DIFF
--- a/db/migrate/20140623152903_create_virtual_gift_card.rb
+++ b/db/migrate/20140623152903_create_virtual_gift_card.rb
@@ -1,4 +1,4 @@
-class CreateVirtualGiftCard < ActiveRecord::Migration
+class CreateVirtualGiftCard < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_virtual_gift_cards do |t|
       t.integer :purchaser_id

--- a/db/migrate/20140623152903_create_virtual_gift_card.rb
+++ b/db/migrate/20140623152903_create_virtual_gift_card.rb
@@ -1,4 +1,4 @@
-class CreateVirtualGiftCard < ActiveRecord::Migration[4.2]
+class CreateVirtualGiftCard < SolidusSupport::Migration[4.2]
   def change
     create_table :spree_virtual_gift_cards do |t|
       t.integer :purchaser_id

--- a/db/migrate/20140624175113_seed_gift_card_category.rb
+++ b/db/migrate/20140624175113_seed_gift_card_category.rb
@@ -1,4 +1,4 @@
-class SeedGiftCardCategory < ActiveRecord::Migration
+class SeedGiftCardCategory < ActiveRecord::Migration[4.2]
   def change
     Spree::StoreCreditCategory.find_or_create_by(name: 'Gift Card')
   end

--- a/db/migrate/20140624175113_seed_gift_card_category.rb
+++ b/db/migrate/20140624175113_seed_gift_card_category.rb
@@ -1,4 +1,4 @@
-class SeedGiftCardCategory < ActiveRecord::Migration[4.2]
+class SeedGiftCardCategory < SolidusSupport::Migration[4.2]
   def change
     Spree::StoreCreditCategory.find_or_create_by(name: 'Gift Card')
   end

--- a/db/migrate/20140627185148_add_timestamps_to_gift_cards.rb
+++ b/db/migrate/20140627185148_add_timestamps_to_gift_cards.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToGiftCards < ActiveRecord::Migration
+class AddTimestampsToGiftCards < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :created_at, :datetime
     add_column :spree_virtual_gift_cards, :updated_at, :datetime

--- a/db/migrate/20140627185148_add_timestamps_to_gift_cards.rb
+++ b/db/migrate/20140627185148_add_timestamps_to_gift_cards.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToGiftCards < ActiveRecord::Migration[4.2]
+class AddTimestampsToGiftCards < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :created_at, :datetime
     add_column :spree_virtual_gift_cards, :updated_at, :datetime

--- a/db/migrate/20140702153907_add_gift_card_flag_to_products.rb
+++ b/db/migrate/20140702153907_add_gift_card_flag_to_products.rb
@@ -1,4 +1,4 @@
-class AddGiftCardFlagToProducts < ActiveRecord::Migration
+class AddGiftCardFlagToProducts < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_products, :gift_card, :boolean, default: false
   end

--- a/db/migrate/20140702153907_add_gift_card_flag_to_products.rb
+++ b/db/migrate/20140702153907_add_gift_card_flag_to_products.rb
@@ -1,4 +1,4 @@
-class AddGiftCardFlagToProducts < ActiveRecord::Migration[4.2]
+class AddGiftCardFlagToProducts < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_products, :gift_card, :boolean, default: false
   end

--- a/db/migrate/20140707200431_add_line_item_to_gift_card.rb
+++ b/db/migrate/20140707200431_add_line_item_to_gift_card.rb
@@ -1,4 +1,4 @@
-class AddLineItemToGiftCard < ActiveRecord::Migration
+class AddLineItemToGiftCard < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :line_item_id, :integer
 

--- a/db/migrate/20140707200431_add_line_item_to_gift_card.rb
+++ b/db/migrate/20140707200431_add_line_item_to_gift_card.rb
@@ -1,4 +1,4 @@
-class AddLineItemToGiftCard < ActiveRecord::Migration[4.2]
+class AddLineItemToGiftCard < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :line_item_id, :integer
 

--- a/db/migrate/20151013172931_add_recipient_fields_to_virtual_gift_card.rb
+++ b/db/migrate/20151013172931_add_recipient_fields_to_virtual_gift_card.rb
@@ -1,4 +1,4 @@
-class AddRecipientFieldsToVirtualGiftCard < ActiveRecord::Migration
+class AddRecipientFieldsToVirtualGiftCard < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :recipient_name, :string
     add_column :spree_virtual_gift_cards, :recipient_email, :string

--- a/db/migrate/20151013172931_add_recipient_fields_to_virtual_gift_card.rb
+++ b/db/migrate/20151013172931_add_recipient_fields_to_virtual_gift_card.rb
@@ -1,4 +1,4 @@
-class AddRecipientFieldsToVirtualGiftCard < ActiveRecord::Migration[4.2]
+class AddRecipientFieldsToVirtualGiftCard < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :recipient_name, :string
     add_column :spree_virtual_gift_cards, :recipient_email, :string

--- a/db/migrate/20151013210615_add_active_flag_to_virtual_gift_card.rb
+++ b/db/migrate/20151013210615_add_active_flag_to_virtual_gift_card.rb
@@ -1,4 +1,4 @@
-class AddActiveFlagToVirtualGiftCard < ActiveRecord::Migration
+class AddActiveFlagToVirtualGiftCard < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :redeemable, :boolean, default: false
   end

--- a/db/migrate/20151013210615_add_active_flag_to_virtual_gift_card.rb
+++ b/db/migrate/20151013210615_add_active_flag_to_virtual_gift_card.rb
@@ -1,4 +1,4 @@
-class AddActiveFlagToVirtualGiftCard < ActiveRecord::Migration[4.2]
+class AddActiveFlagToVirtualGiftCard < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :redeemable, :boolean, default: false
   end

--- a/db/migrate/20151013214647_set_redeemable_true_on_virtual_gift_cards.rb
+++ b/db/migrate/20151013214647_set_redeemable_true_on_virtual_gift_cards.rb
@@ -1,4 +1,4 @@
-class SetRedeemableTrueOnVirtualGiftCards < ActiveRecord::Migration
+class SetRedeemableTrueOnVirtualGiftCards < ActiveRecord::Migration[4.2]
   def up
     Spree::VirtualGiftCard.find_each do |gift_card|
       gift_card.update_attributes!(redeemable: true)

--- a/db/migrate/20151013214647_set_redeemable_true_on_virtual_gift_cards.rb
+++ b/db/migrate/20151013214647_set_redeemable_true_on_virtual_gift_cards.rb
@@ -1,4 +1,4 @@
-class SetRedeemableTrueOnVirtualGiftCards < ActiveRecord::Migration[4.2]
+class SetRedeemableTrueOnVirtualGiftCards < SolidusSupport::Migration[4.2]
   def up
     Spree::VirtualGiftCard.find_each do |gift_card|
       gift_card.update_attributes!(redeemable: true)

--- a/db/migrate/20151019190731_add_email_send_time_to_virtual_gift_card.rb
+++ b/db/migrate/20151019190731_add_email_send_time_to_virtual_gift_card.rb
@@ -1,4 +1,4 @@
-class AddEmailSendTimeToVirtualGiftCard < ActiveRecord::Migration
+class AddEmailSendTimeToVirtualGiftCard < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :send_email_at, :date
     add_column :spree_virtual_gift_cards, :sent_at, :datetime

--- a/db/migrate/20151019190731_add_email_send_time_to_virtual_gift_card.rb
+++ b/db/migrate/20151019190731_add_email_send_time_to_virtual_gift_card.rb
@@ -1,4 +1,4 @@
-class AddEmailSendTimeToVirtualGiftCard < ActiveRecord::Migration[4.2]
+class AddEmailSendTimeToVirtualGiftCard < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :send_email_at, :date
     add_column :spree_virtual_gift_cards, :sent_at, :datetime

--- a/db/migrate/20151109202300_add_deactivated_at_to_gift_card.rb
+++ b/db/migrate/20151109202300_add_deactivated_at_to_gift_card.rb
@@ -1,4 +1,4 @@
-class AddDeactivatedAtToGiftCard < ActiveRecord::Migration
+class AddDeactivatedAtToGiftCard < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :deactivated_at, :datetime
   end

--- a/db/migrate/20151109202300_add_deactivated_at_to_gift_card.rb
+++ b/db/migrate/20151109202300_add_deactivated_at_to_gift_card.rb
@@ -1,4 +1,4 @@
-class AddDeactivatedAtToGiftCard < ActiveRecord::Migration[4.2]
+class AddDeactivatedAtToGiftCard < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :deactivated_at, :datetime
   end

--- a/db/migrate/20151110202752_add_inventory_unit_to_gift_card.rb
+++ b/db/migrate/20151110202752_add_inventory_unit_to_gift_card.rb
@@ -1,4 +1,4 @@
-class AddInventoryUnitToGiftCard < ActiveRecord::Migration
+class AddInventoryUnitToGiftCard < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :inventory_unit_id, :integer
   end

--- a/db/migrate/20151110202752_add_inventory_unit_to_gift_card.rb
+++ b/db/migrate/20151110202752_add_inventory_unit_to_gift_card.rb
@@ -1,4 +1,4 @@
-class AddInventoryUnitToGiftCard < ActiveRecord::Migration[4.2]
+class AddInventoryUnitToGiftCard < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_virtual_gift_cards, :inventory_unit_id, :integer
   end

--- a/db/migrate/20151111211220_backfill_inventory_units_on_gift_card.rb
+++ b/db/migrate/20151111211220_backfill_inventory_units_on_gift_card.rb
@@ -1,4 +1,4 @@
-class BackfillInventoryUnitsOnGiftCard < ActiveRecord::Migration[4.2]
+class BackfillInventoryUnitsOnGiftCard < SolidusSupport::Migration[4.2]
   def up
     gift_card_products = Spree::Product.where(gift_card: true)
 

--- a/db/migrate/20151111211220_backfill_inventory_units_on_gift_card.rb
+++ b/db/migrate/20151111211220_backfill_inventory_units_on_gift_card.rb
@@ -1,4 +1,4 @@
-class BackfillInventoryUnitsOnGiftCard < ActiveRecord::Migration
+class BackfillInventoryUnitsOnGiftCard < ActiveRecord::Migration[4.2]
   def up
     gift_card_products = Spree::Product.where(gift_card: true)
 


### PR DESCRIPTION
Starting in Rails 5.0, database migrations are versioned, with 4.2 being the oldest unmarked version. Current versions of Rails require version numbers, or else the migrations will throw an exception. This PR adds the default legacy version of `[4.2]` to all `solidus_virtual_gift_card` migrations.