### PR TITLE
update line item option syntax post-Solidus 2.3

### DIFF
--- a/config/initializers/line_item_controller_gift_card_details.rb
+++ b/config/initializers/line_item_controller_gift_card_details.rb
@@ -1,4 +1,4 @@
 Rails.application.config.to_prepare do
-  Spree::Api::LineItemsController.line_item_options += [gift_card_details: [:recipient_name, :recipient_email, :gift_message, :purchaser_name, :send_email_at]]
+  Spree::PermittedAttributes.line_item_attributes << { options: [gift_card_details: [:recipient_name, :recipient_email, :gift_message, :purchaser_name, :send_email_at]] }
   Spree::Order.line_item_comparison_hooks.add('gift_card_match')
 end


### PR DESCRIPTION
This updates the line item options to the new syntax following https://github.com/solidusio/solidus/pull/1943, which was merged into Solidus 2.3 and later.