### PR TITLE
static attributes deprecated in FactoryBot 4.11

### DIFF
--- a/lib/spree_virtual_gift_card/factories.rb
+++ b/lib/spree_virtual_gift_card/factories.rb
@@ -1,14 +1,14 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :store_credit_gift_card_category, class: Spree::StoreCreditCategory do
-    name Spree::StoreCreditCategory::GIFT_CARD_CATEGORY_NAME
+    name { Spree::StoreCreditCategory::GIFT_CARD_CATEGORY_NAME }
   end
 
   factory :virtual_gift_card, class: Spree::VirtualGiftCard do
     association :line_item, factory: :line_item
-    amount 25.0
-    currency 'USD'
-    recipient_name 'Tom Riddle'
-    recipient_email 'me@lordvoldemort.com'
+    amount { 25.0 }
+    currency { 'USD' }
+    recipient_name { 'Tom Riddle' }
+    recipient_email { 'me@lordvoldemort.com' }
 
     factory :redeemable_virtual_gift_card do
       association :purchaser, factory: :user
@@ -17,7 +17,7 @@ FactoryGirl.define do
           create(:inventory_unit, line_item: gift_card.line_item)
       end
 
-      redeemable true
+      redeemable { true }
 
       before(:create) do |gift_card, evaluator|
         gift_card.redemption_code = gift_card.send(:generate_unique_redemption_code)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,7 +54,7 @@ RSpec.configure do |config|
 
   config.example_status_persistence_file_path = './spec/examples.txt'
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::UrlHelpers, type: :controller
 


### PR DESCRIPTION
FactoryBot >= 4.11 deprecated the use of static attributes, and these were later removed. This change is necessary for specs to pass in current versions of FactoryBot.